### PR TITLE
Update corner hint tool input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This table describes the tool surface exposed by the MCP server shipped in this 
 | `get_selected_glyphs` | Info about glyphs currently selected in UI. |
 | `get_selected_font_and_master` | Current font + master and selection snapshot. |
 | `get_selected_nodes` | Detailed selected nodes with per‑master mapping for edits. |
-| `add_croner_corner_to_all_masters` | Add a `_corner.*` corner hint at selected nodes (and intersection handles) across all masters (requires `_corner_name`). |
+| `add_corner_to_all_masters` | Add a `_corner.*` corner hint at selected nodes (and intersection handles) across all masters (requires `_corner_name`). |
 | `get_glyph_paths` | Export paths in a JSON format suitable for LLM editing. |
 | `set_glyph_paths` | Replace glyph paths from JSON. |
 | `ExportDesignspaceAndUFO` | Export designspace/UFO bundles with structured logs and errors. |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This table describes the tool surface exposed by the MCP server shipped in this 
 | `get_selected_glyphs` | Info about glyphs currently selected in UI. |
 | `get_selected_font_and_master` | Current font + master and selection snapshot. |
 | `get_selected_nodes` | Detailed selected nodes with per‑master mapping for edits. |
-| `add_croner_corner_to_all_masters` | Add `_corner.croner` corner hints at selected nodes (and intersection handles) across all masters. |
+| `add_croner_corner_to_all_masters` | Add a `_corner.*` corner hint at selected nodes (and intersection handles) across all masters (requires `_corner_name`). |
 | `get_glyph_paths` | Export paths in a JSON format suitable for LLM editing. |
 | `set_glyph_paths` | Replace glyph paths from JSON. |
 | `ExportDesignspaceAndUFO` | Export designspace/UFO bundles with structured logs and errors. |

--- a/src/glyphs-mcp/Glyphs MCP.glyphsPlugin/Contents/Resources/mcp_tools.py
+++ b/src/glyphs-mcp/Glyphs MCP.glyphsPlugin/Contents/Resources/mcp_tools.py
@@ -1613,7 +1613,7 @@ async def get_selected_nodes(include_master_mapping: bool = True) -> str:
 
 
 @mcp.tool()
-async def add_croner_corner_to_all_masters(corner_name: str = "_corner.croner") -> str:
+async def add_croner_corner_to_all_masters(_corner_name: str | None = None) -> str:
     """Add a corner component hint at the selected node(s) across all masters.
 
     This tool:
@@ -1624,7 +1624,7 @@ async def add_croner_corner_to_all_masters(corner_name: str = "_corner.croner") 
     - Skips + reports masters where the corresponding path/node index is missing.
 
     Args:
-        corner_name: Corner component name (e.g. ``_corner.croner``).
+        _corner_name: Corner component name (e.g. ``_corner.inktrap``). Required.
 
     Returns:
         JSON encoded result with per-master add/skip details.
@@ -1633,6 +1633,51 @@ async def add_croner_corner_to_all_masters(corner_name: str = "_corner.croner") 
         font = Glyphs.font
         if not font:
             return json.dumps({"error": "No font is currently active"})
+
+        def _available_corner_names(current_font):
+            names = []
+            try:
+                glyphs = getattr(current_font, "glyphs", []) or []
+            except Exception:
+                glyphs = []
+            for g in glyphs:
+                try:
+                    name = getattr(g, "name", None)
+                except Exception:
+                    continue
+                if isinstance(name, str) and name.startswith("_corner."):
+                    names.append(name)
+            return sorted(set(names))
+
+        available_corners = _available_corner_names(font)
+        corner_name = (_corner_name or "").strip() if _corner_name is not None else ""
+        if not corner_name:
+            return json.dumps(
+                {
+                    "error": "Missing required parameter: _corner_name",
+                    "directive": "Re-run add_croner_corner_to_all_masters and pass `_corner_name` set to one of `availableCorners` (full Glyphs corner component glyph name, e.g. `_corner.inktrap`).",
+                    "availableCorners": available_corners,
+                    "example": {"_corner_name": available_corners[0] if available_corners else "_corner.<name>"},
+                }
+            )
+        if not corner_name.startswith("_corner."):
+            return json.dumps(
+                {
+                    "error": "Invalid _corner_name (must start with '_corner.')",
+                    "cornerName": corner_name,
+                    "directive": "Pass the full corner glyph name, e.g. `_corner.inktrap`. Choose one from `availableCorners` and retry.",
+                    "availableCorners": available_corners,
+                }
+            )
+        if available_corners and corner_name not in available_corners:
+            return json.dumps(
+                {
+                    "error": "Corner component not found in current font",
+                    "cornerName": corner_name,
+                    "directive": "Choose a value from `availableCorners` and retry. If the corner glyph is missing, create it in the font first.",
+                    "availableCorners": available_corners,
+                }
+            )
 
         if not font.selectedLayers or len(font.selectedLayers) == 0:
             return json.dumps({"error": "No active layer/glyph open in Edit view"})
@@ -1723,6 +1768,7 @@ async def add_croner_corner_to_all_masters(corner_name: str = "_corner.croner") 
                 {
                     "error": "No applicable nodes/handles selected (select on-curve nodes or intersection handles)",
                     "cornerName": corner_name,
+                    "availableCorners": available_corners,
                     "skippedSelection": skipped_selection,
                 }
             )
@@ -1920,6 +1966,7 @@ async def add_croner_corner_to_all_masters(corner_name: str = "_corner.croner") 
             {
                 "success": True,
                 "cornerName": corner_name,
+                "availableCorners": available_corners,
                 "font": {
                     "familyName": getattr(font, "familyName", "") or "",
                     "filePath": getattr(font, "filepath", None),

--- a/src/glyphs-mcp/Glyphs MCP.glyphsPlugin/Contents/Resources/mcp_tools.py
+++ b/src/glyphs-mcp/Glyphs MCP.glyphsPlugin/Contents/Resources/mcp_tools.py
@@ -1613,7 +1613,7 @@ async def get_selected_nodes(include_master_mapping: bool = True) -> str:
 
 
 @mcp.tool()
-async def add_croner_corner_to_all_masters(_corner_name: str | None = None) -> str:
+async def add_corner_to_all_masters(_corner_name: str | None = None) -> str:
     """Add a corner component hint at the selected node(s) across all masters.
 
     This tool:
@@ -1655,7 +1655,7 @@ async def add_croner_corner_to_all_masters(_corner_name: str | None = None) -> s
             return json.dumps(
                 {
                     "error": "Missing required parameter: _corner_name",
-                    "directive": "Re-run add_croner_corner_to_all_masters and pass `_corner_name` set to one of `availableCorners` (full Glyphs corner component glyph name, e.g. `_corner.inktrap`).",
+                    "directive": "Re-run add_corner_to_all_masters and pass `_corner_name` set to one of `availableCorners` (full Glyphs corner component glyph name, e.g. `_corner.inktrap`).",
                     "availableCorners": available_corners,
                     "example": {"_corner_name": available_corners[0] if available_corners else "_corner.<name>"},
                 }


### PR DESCRIPTION
Summary
- rename the tool to `add_corner_to_all_masters` to reflect the new required `_corner_name` parameter
- validate `_corner_name` against existing `_corner.*` glyphs and return helpful directives when missing or invalid
- expose available corner names in success/failure payloads to guide callers
Testing
- Not run (not requested)