### PR TITLE
Document Italify as an alternative

### DIFF
--- a/content/contributor/italic-balanced-inter-v4.1-report.md
+++ b/content/contributor/italic-balanced-inter-v4.1-report.md
@@ -79,3 +79,7 @@ No Italify source, executable, package, private API, data model, identifiers,
 or implementation details were inspected, decompiled, invoked, or copied.
 The detector, interpolation model, constraints, diagnostics, names, tests, and
 thresholds in this repository are original to this implementation.
+
+For designers who prefer a dedicated in-app plugin,
+[Italify](https://www.sebastiancarewe.com/italify/) is a solid alternative to
+the experimental Glyphs MCP italicification workflow.


### PR DESCRIPTION
## Summary

Adds a brief note to the Inter v4.1 Balanced italicification report identifying Italify as a solid dedicated in-app alternative to the experimental Glyphs MCP workflow.

## Why

Designers reading the clean-room provenance section should have a clear path to the existing dedicated plugin when that better fits their workflow.

## Impact

Documentation only; no runtime behavior changes.

## Validation

- `git diff --check`
- Confirmed the linked Italify page responds with HTTP 200